### PR TITLE
refactor: axios から fetch に移行する

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,9 @@
     "typescript-json-schema": "0.67.1"
   },
   "packageManager": "pnpm@10.33.0+sha512.10568bb4a6afb58c9eb3630da90cc9516417abebd3fabbe6739f0ae795728da1491e9db5a544c76ad8eb7570f5c4bb3d6c637b2cb41bfdcdb47fa823c8649319",
+  "engines": {
+    "node": ">=18"
+  },
   "pnpm": {
     "onlyBuiltDependencies": [
       "esbuild"

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "@book000/eslint-config": "1.14.9",
     "@book000/node-utils": "1.24.123",
     "@types/node": "24.12.2",
-    "axios": "1.15.0",
     "eslint": "10.2.0",
     "eslint-config-standard": "17.1.0",
     "eslint-plugin-import": "2.32.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,9 +17,6 @@ importers:
       '@types/node':
         specifier: 24.12.2
         version: 24.12.2
-      axios:
-        specifier: 1.15.0
-        version: 1.15.0
       eslint:
         specifier: 10.2.0
         version: 10.2.0
@@ -505,9 +502,6 @@ packages:
 
   axios@1.14.0:
     resolution: {integrity: sha512-3Y8yrqLSwjuzpXuZ0oIYZ/XGgLwUIBU3uLvbcpb0pidD9ctpShJd43KSlEEkVQg6DS0G9NKyzOvBfUtDKEyHvQ==}
-
-  axios@1.15.0:
-    resolution: {integrity: sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==}
 
   b4a@1.8.0:
     resolution: {integrity: sha512-qRuSmNSkGQaHwNbM7J78Wwy+ghLEYF1zNrSeMxj4Kgw6y33O3mXcQ6Ie9fRvfU/YnxWkOchPXbaLb73TkIsfdg==}
@@ -2474,14 +2468,6 @@ snapshots:
       possible-typed-array-names: 1.1.0
 
   axios@1.14.0:
-    dependencies:
-      follow-redirects: 1.15.11
-      form-data: 4.0.5
-      proxy-from-env: 2.1.0
-    transitivePeerDependencies:
-      - debug
-
-  axios@1.15.0:
     dependencies:
       follow-redirects: 1.15.11
       form-data: 4.0.5

--- a/src/main.ts
+++ b/src/main.ts
@@ -29,7 +29,8 @@ function getRgWishlistData(html: string): WishlistItem[] {
 async function getWishlistAppIds(profileId: string): Promise<number[]> {
   const url = `https://store.steampowered.com/wishlist/id/${profileId}/`
   const res = await fetch(url)
-  if (!res.ok) throw new Error(`HTTP error: ${res.status}`)
+  if (!res.ok)
+    throw new Error(`HTTP error: ${res.status} ${res.statusText} (${url})`)
   const data = await res.text()
   const rgWishlistData = getRgWishlistData(data)
   return rgWishlistData.map((item) => item.appid)

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,7 +1,6 @@
 import { Configuration, PATH } from './config'
 import fs from 'node:fs'
 import { getApps, WishlistItem } from './steam'
-import axios from 'axios'
 import { Notified } from './notified'
 import { getLowestPrice } from './steamdb'
 import { Discord, DiscordEmbedField, Logger } from '@book000/node-utils'
@@ -29,8 +28,10 @@ function getRgWishlistData(html: string): WishlistItem[] {
 
 async function getWishlistAppIds(profileId: string): Promise<number[]> {
   const url = `https://store.steampowered.com/wishlist/id/${profileId}/`
-  const response = await axios.get(url)
-  const rgWishlistData = getRgWishlistData(response.data)
+  const res = await fetch(url)
+  if (!res.ok) throw new Error(`HTTP error: ${res.status}`)
+  const data = await res.text()
+  const rgWishlistData = getRgWishlistData(data)
   return rgWishlistData.map((item) => item.appid)
 }
 

--- a/src/steam.ts
+++ b/src/steam.ts
@@ -172,7 +172,8 @@ export type AppResponse = Record<number, AppResult>
 export async function getApp(appId: number): Promise<AppData> {
   const url = `https://store.steampowered.com/api/appdetails?appids=${appId}&cc=JP`
   const res = await fetch(url)
-  if (!res.ok) throw new Error(`HTTP error: ${res.status}`)
+  if (!res.ok)
+    throw new Error(`HTTP error: ${res.status} ${res.statusText} (${url})`)
   const response = (await res.json()) as AppResponse
   if (!response[appId].success) {
     throw new Error(`Failed to get app data for app id ${appId}`)

--- a/src/steam.ts
+++ b/src/steam.ts
@@ -1,5 +1,3 @@
-import axios from 'axios'
-
 export interface WishlistItem {
   appid: number
   priority: number
@@ -173,11 +171,13 @@ export type AppResponse = Record<number, AppResult>
 
 export async function getApp(appId: number): Promise<AppData> {
   const url = `https://store.steampowered.com/api/appdetails?appids=${appId}&cc=JP`
-  const response = await axios.get<AppResponse>(url)
-  if (!response.data[appId].success) {
+  const res = await fetch(url)
+  if (!res.ok) throw new Error(`HTTP error: ${res.status}`)
+  const response = (await res.json()) as AppResponse
+  if (!response[appId].success) {
     throw new Error(`Failed to get app data for app id ${appId}`)
   }
-  return response.data[appId].data
+  return response[appId].data
 }
 
 export async function getApps(appIds: number[]): Promise<AppData[]> {


### PR DESCRIPTION
fix book000/book000#102

axiosへの依存を削除し、ネイティブ fetch API に移行しました。

## 変更内容
- `axios` 依存を削除
- `fetch` API を使用するように変更
- 非2xxレスポンスに対するエラーハンドリングを追加