### PR TITLE
fix: Docker ビルドで pnpm v11 動作に必要な Node.js を 22 LTS に更新

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,6 @@
+# pnpm v11 は Node.js 22+ が必要なため、node:22-alpine から Node.js バイナリをコピーする
+FROM node:22-alpine AS node
+
 FROM zenika/alpine-chrome:with-puppeteer-xvfb AS runner
 
 ENV PNPM_HOME="/pnpm"
@@ -6,14 +9,26 @@ ENV PATH="$PNPM_HOME/bin:$PATH"
 # hadolint ignore=DL3002
 USER root
 
-# hadolint ignore=DL3018,DL3016
+# Node.js 22 のバイナリおよびモジュールをコピーして既存の Node.js 20 を置き換える
+# npm/npx/corepack はシンボリックリンクのため、node_modules ごとコピーしてリンクを再作成する
+COPY --from=node /usr/local/bin/node /usr/local/bin/node
+COPY --from=node /usr/local/lib/node_modules /usr/local/lib/node_modules
+
+# /usr/bin/node および /usr/local/bin のシンボリックリンクを再作成する
+RUN ln -sf /usr/local/bin/node /usr/bin/node && \
+  ln -sf /usr/local/lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm && \
+  ln -sf /usr/local/lib/node_modules/npm/bin/npx-cli.js /usr/local/bin/npx && \
+  ln -sf /usr/local/lib/node_modules/corepack/dist/corepack.js /usr/local/bin/corepack && \
+  ln -sf /usr/local/bin/npm /usr/bin/npm && \
+  ln -sf /usr/local/bin/npx /usr/bin/npx
+
+# hadolint ignore=DL3018
 RUN apk upgrade --no-cache --available && \
   apk update && \
   apk add --update --no-cache tzdata x11vnc && \
   cp /usr/share/zoneinfo/Asia/Tokyo /etc/localtime && \
   echo "Asia/Tokyo" > /etc/timezone && \
   apk del tzdata && \
-  npm install -g corepack@latest && \
   corepack enable
 
 WORKDIR /app


### PR DESCRIPTION
## 概要

pnpm v11 は ESM 配布のため Node.js 22+ が必要ですが、`zenika/alpine-chrome:with-puppeteer-xvfb` ベースイメージには Node.js 20.15.1 が含まれており、Renovate PR #2183 (`chore(deps): update pnpm to v11`) の Docker CI で `ERR_VM_DYNAMIC_IMPORT_CALLBACK_MISSING` エラーが発生します。

## 変更内容

- マルチステージビルドを使用し、`node:22-alpine` から Node.js 22 のバイナリおよびモジュールをコピー
- `zenika/alpine-chrome:with-puppeteer-xvfb` ベースイメージ上の Node.js 20 を Node.js 22 で上書き
- `npm`、`npx`、`corepack` のシンボリックリンクを Node.js 22 のモジュールに向けて再作成
- `npm install -g corepack@latest` を削除し、`node:22-alpine` に同梱済みの corepack を利用

## 背景・原因

- `zenika/alpine-chrome` は Alpine Linux 3.19 ベースで、Alpine のパッケージリポジトリには Node.js 22 が提供されていない
- pnpm v11 は ESM 配布となり、古い Node.js では `ERR_VM_DYNAMIC_IMPORT_CALLBACK_MISSING` が発生する
- pnpm v11 の最低要件: Node.js 22+

## 動作確認

ローカルでの Docker ビルドで以下を確認済み:

- `node --version` → `v22.22.3`
- `pnpm --version` → `10.33.4`（現在のバージョン）
- hadolint によるエラーなし

## 関連 PR

- Renovate PR #2183 (`chore(deps): update pnpm to v11`) の CI 修正を目的とした変更
  - 本 PR は Renovate PR とは独立しており、`master` ブランチへのマージを意図する