### PR TITLE
chore: エージェント向けドキュメントを整理し CLAUDE.md と copilot-instructions.md に統一

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,30 +1,30 @@
-# Copilot code review instructions
+# GitHub Copilot コードレビュー向け指示
 
-This is a .NET 10 Azure Durable Functions app (isolated worker) that crawls a Steam wishlist and notifies Discord of price drops. Review C# changes against the points below.
+本リポジトリは Steam のウィッシュリストを巡回し値下がりを Discord に通知する、.NET 10 Azure Durable Functions アプリ(isolated worker)です。C# の変更は以下の観点でレビューしてください。
 
-## Durable Functions correctness (highest priority)
+## Durable Functions の正しさ(最優先)
 
-- Flag non-deterministic code inside the orchestrator (`Orchestrations/`): `DateTime.Now`/`DateTime.UtcNow`, `Guid.NewGuid()`, random, environment reads, direct HTTP/file I/O, or `Task.Delay`. Such work belongs in an activity or must use the Durable-provided context APIs.
-- Orchestrators should only coordinate activities and use durable timers/context; business logic and external calls belong in `Activities/`.
-- Watch for changes that break the singleton pattern in `Triggers/Crawler.cs` (fixed instance ID per profile, skip when an instance is already `Running`/`Pending`) — losing it allows overlapping runs.
-- Preserve the "first run skips notification" behavior: the entity (`Entities/NotificationStateEntity.cs`) reports `isFirstRun` on its first call, and the orchestrator skips Discord notification while it is true. Flag changes that break either side.
+- オーケストレータ(`Orchestrations/`)内の非決定的なコードを指摘する: `DateTime.Now`/`DateTime.UtcNow`、`Guid.NewGuid()`、乱数、環境変数の読み取り、直接の HTTP/ファイル I/O、`Task.Delay` など。これらはアクティビティに置くか、Durable が提供するコンテキスト API を使う必要がある。
+- オーケストレータはアクティビティの調整と durable なタイマー/コンテキストの利用のみを行うべき。ビジネスロジックや外部呼び出しは `Activities/` に置く。
+- `Triggers/Crawler.cs` のシングルトンパターン(プロファイルごとの固定インスタンス ID、既に `Running`/`Pending` の場合はスキップ)を壊す変更に注意する。壊すと実行が重複しうる。
+- 「初回実行は通知をスキップする」挙動を維持する: エンティティ(`Entities/NotificationStateEntity.cs`)が初回呼び出し時に `isFirstRun` を報告し、オーケストレータがそれが true の間 Discord 通知をスキップする。どちらか片方だけを壊す変更を指摘する。
 
-## Conventions enforced in this repo
+## このリポジトリで強制される規約
 
-- Function names must use `Common/FunctionNames.cs` constants, not string literals.
-- HTTP access must go through the injected `IHttpClientFactory`; flag any `new HttpClient()`.
-- Every public type/member needs an XML doc comment (`///`) — the build warns otherwise.
-- Code comments and XML docs are written in Japanese; log and exception messages in English. Do not flag Japanese comments as an issue.
-- Prefer `record` types for models/DTOs. Nullable reference types are enabled — flag suppressed or dishonest nullability (`!` without justification).
+- Function 名は `Common/FunctionNames.cs` の定数を使用し、文字列リテラルを使わない。
+- HTTP アクセスは注入された `IHttpClientFactory` 経由で行う。`new HttpClient()` は指摘する。
+- public な型・メンバーには XML doc コメント(`///`)が必要(無いとビルド警告になる)。
+- コード内コメントと XML doc は日本語、ログ・例外メッセージは英語で書かれている。日本語コメントを問題として指摘しない。
+- モデル/DTO は `record` 型を優先する。Nullable reference types が有効なため、抑制された・不誠実な null 許容性(根拠のない `!`)を指摘する。
 
-## Security & configuration
+## セキュリティ・設定
 
-- Flag any hardcoded secrets or environment-specific values (Discord webhook URLs, `ITAD_API_KEY`, `STEAM_PROFILE_ID`); these must be read via `IConfiguration`.
-- `local.settings.json` must never be added to the repo.
-- Confirm external HTTP responses are checked (`IsSuccessStatusCode`) and deserialization results are null-checked before use, since Steam/ITAD/CheapShark responses are untrusted.
+- ハードコードされたシークレットや環境固有の値(Discord Webhook URL、`ITAD_API_KEY`、`STEAM_PROFILE_ID`)を指摘する。これらは `IConfiguration` 経由で取得する必要がある。
+- `local.settings.json` は絶対にリポジトリに追加しない。
+- Steam/ITAD/CheapShark のレスポンスは信頼できないため、外部 HTTP レスポンスのステータスチェック(`IsSuccessStatusCode`)とデシリアライズ結果の null チェックが行われているか確認する。
 
-## Do not flag
+## 指摘すべきでない事項
 
-- CRLF line endings, 4-space indentation, and allman braces — these are enforced by `.editorconfig`.
-- Japanese-language comments and documentation.
-- The learning-oriented long-form docs under `docs/`.
+- CRLF 改行、4 スペースインデント、allman ブレース — `.editorconfig` で強制されている。
+- 日本語のコメント・ドキュメント。
+- `docs/` 配下の学習用ロングフォームドキュメント。

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,30 @@
+# Copilot code review instructions
+
+This is a .NET 10 Azure Durable Functions app (isolated worker) that crawls a Steam wishlist and notifies Discord of price drops. Review C# changes against the points below.
+
+## Durable Functions correctness (highest priority)
+
+- Flag non-deterministic code inside the orchestrator (`Orchestrations/`): `DateTime.Now`/`DateTime.UtcNow`, `Guid.NewGuid()`, random, environment reads, direct HTTP/file I/O, or `Task.Delay`. Such work belongs in an activity or must use the Durable-provided context APIs.
+- Orchestrators should only coordinate activities and use durable timers/context; business logic and external calls belong in `Activities/`.
+- Watch for changes that break the singleton pattern in `Triggers/Crawler.cs` (fixed instance ID per profile, skip when an instance is already `Running`/`Pending`) — losing it allows overlapping runs.
+- Preserve the "first run skips notification" behavior: the entity (`Entities/NotificationStateEntity.cs`) reports `isFirstRun` on its first call, and the orchestrator skips Discord notification while it is true. Flag changes that break either side.
+
+## Conventions enforced in this repo
+
+- Function names must use `Common/FunctionNames.cs` constants, not string literals.
+- HTTP access must go through the injected `IHttpClientFactory`; flag any `new HttpClient()`.
+- Every public type/member needs an XML doc comment (`///`) — the build warns otherwise.
+- Code comments and XML docs are written in Japanese; log and exception messages in English. Do not flag Japanese comments as an issue.
+- Prefer `record` types for models/DTOs. Nullable reference types are enabled — flag suppressed or dishonest nullability (`!` without justification).
+
+## Security & configuration
+
+- Flag any hardcoded secrets or environment-specific values (Discord webhook URLs, `ITAD_API_KEY`, `STEAM_PROFILE_ID`); these must be read via `IConfiguration`.
+- `local.settings.json` must never be added to the repo.
+- Confirm external HTTP responses are checked (`IsSuccessStatusCode`) and deserialization results are null-checked before use, since Steam/ITAD/CheapShark responses are untrusted.
+
+## Do not flag
+
+- CRLF line endings, 4-space indentation, and allman braces — these are enforced by `.editorconfig`.
+- Japanese-language comments and documentation.
+- The learning-oriented long-form docs under `docs/`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,54 +1,54 @@
 # CLAUDE.md
 
-## Overview
+## 概要
 
-`WatchWishlistSale` is a serverless batch app built on **Azure Durable Functions** (.NET 10, isolated worker model). It runs hourly, crawls a Steam wishlist, detects apps that are on sale and have dropped in price since the last notification, and posts them to Discord. Lowest-ever prices are fetched from IsThereAnyDeal / CheapShark.
+`WatchWishlistSale` は **Azure Durable Functions**(.NET 10、isolated worker モデル)で構築されたサーバーレスのバッチアプリです。毎時実行され、Steam のウィッシュリストを巡回し、セール中かつ前回通知時から値下がりしたアプリを検出して Discord に通知します。歴代最安値は IsThereAnyDeal / CheapShark から取得します。
 
-## Development commands
+## 開発コマンド
 
-- `dotnet restore` — restore dependencies.
-- `dotnet build --configuration Release` — build. Run before committing; CI runs the same. Keep the build warning-free (StyleCop.Analyzers and `GenerateDocumentationFile` warnings are treated as review blockers).
-- `func start` — run locally. Requires **Azurite** (Storage emulator) running in another terminal and a `local.settings.json` file (see below).
-- Manually trigger the timer without waiting for the top of the hour:
-  `POST http://localhost:7071/admin/functions/RunCrawler` with body `{ "input": "" }`.
+- `dotnet restore` — 依存関係の復元。
+- `dotnet build --configuration Release` — ビルド。コミット前に実行すること。CI も同一コマンドを実行する。ビルド警告はゼロに保つ(StyleCop.Analyzers と `GenerateDocumentationFile` の警告はレビューブロッカーとして扱う)。
+- `func start` — ローカル実行。別ターミナルで **Azurite**(ストレージエミュレータ)の起動と `local.settings.json` が必要(詳細は下記)。
+- 毎時の実行を待たずにタイマーを手動発火する場合:
+  `POST http://localhost:7071/admin/functions/RunCrawler` にボディ `{ "input": "" }` を送信。
 
-There is no test project. Verify changes by building and by running the flow locally against Azurite (see `docs/06-local-development.md`).
+テストプロジェクトは存在しない。変更の検証はビルドと、Azurite を使ったローカルでのフロー実行で行う(`docs/06-local-development.md` 参照)。
 
-## Architecture
+## アーキテクチャ
 
-Durable Functions splits work into three roles. Data flows Trigger → Orchestrator → Activities, with an Entity holding cross-run state.
+Durable Functions は処理を 3 つの役割に分割する。データは Trigger → Orchestrator → Activities と流れ、Entity が実行をまたいだ状態を保持する。
 
-- `Triggers/` — entry points. `Crawler.cs` is the hourly `TimerTrigger` that starts the orchestration.
-- `Orchestrations/` — `WatchWishlistOrchestrator.cs`. Coordinates activities (fan-out/fan-in). **Must stay deterministic**: no `DateTime.Now`, random, direct I/O, or non-durable async — call activities for anything non-deterministic.
-- `Activities/` — the actual work (HTTP calls, filtering, Discord notification). One class per activity.
-- `Entities/` — `NotificationStateEntity.cs`, a Durable Entity persisting notified-sale state across runs.
-- `Models/` — DTOs grouped by domain: `Wishlist/`, `Pricing/`, `Notification/`.
-- `Common/FunctionNames.cs` — central constants for every Function name.
-- `Program.cs` — DI/host setup (registers `IHttpClientFactory`, OpenTelemetry).
+- `Triggers/` — エントリポイント。`Crawler.cs` は毎時実行される `TimerTrigger` で、オーケストレーションを開始する。
+- `Orchestrations/` — `WatchWishlistOrchestrator.cs`。アクティビティを調整する(fan-out/fan-in)。**決定論的でなければならない**: `DateTime.Now`、乱数、直接の I/O、durable でない非同期処理は禁止。非決定的な処理はすべてアクティビティ経由で呼び出す。
+- `Activities/` — 実際の処理(HTTP 呼び出し、フィルタリング、Discord 通知)。1 アクティビティ 1 クラス。
+- `Entities/` — `NotificationStateEntity.cs`。通知済みセール状態を実行をまたいで永続化する Durable Entity。
+- `Models/` — ドメインごとに分類された DTO: `Wishlist/`、`Pricing/`、`Notification/`。
+- `Common/FunctionNames.cs` — 全 Function 名の定数を集約。
+- `Program.cs` — DI/ホストのセットアップ(`IHttpClientFactory`、OpenTelemetry を登録)。
 
-Deeper design and a code walkthrough live in `docs/` (learning-oriented, Japanese).
+より詳細な設計とコードウォークスルーは `docs/` 配下にある(学習用ドキュメント)。
 
-## Coding conventions
+## コーディング規約
 
-- **Language**: code comments and XML doc comments in **Japanese** (match existing files); log/exception messages in **English**.
-- **XML docs required**: `GenerateDocumentationFile` is on, so every public type/member needs a `///` summary or the build warns.
-- **Function names**: reference `FunctionNames.*` constants, never string literals, for `[Function(...)]` attributes and orchestration/activity/entity calls.
-- **HTTP**: get clients from the injected `IHttpClientFactory` using a named client (`CreateClient(nameof(TheClass))`); do not `new HttpClient()`.
-- **Models**: prefer `record` types; `Nullable` and `ImplicitUsings` are enabled — annotate nullability honestly and rely on implicit usings.
-- **Formatting** (`.editorconfig`, enforced): 4-space indent, **CRLF** line endings, UTF-8, final newline, allman braces. JSON/YAML/XML use 2-space indent.
+- **言語**: コード内コメントおよび XML doc コメントは **日本語**(既存ファイルに合わせる)、ログ・例外メッセージは **英語**。
+- **XML doc 必須**: `GenerateDocumentationFile` が有効なため、public な型・メンバーには `///` summary が必要(無いとビルド警告になる)。
+- **Function 名**: `[Function(...)]` 属性やオーケストレーション/アクティビティ/エンティティの呼び出しでは、文字列リテラルではなく `FunctionNames.*` 定数を参照する。
+- **HTTP**: クライアントは注入された `IHttpClientFactory` から名前付きクライアント(`CreateClient(nameof(TheClass))`)として取得する。`new HttpClient()` は禁止。
+- **モデル**: `record` 型を優先する。`Nullable` と `ImplicitUsings` が有効なため、null 許容性を正直に注釈し、implicit usings に依存する。
+- **フォーマット**(`.editorconfig` で強制): 4 スペースインデント、**CRLF** 改行、UTF-8、ファイル末尾改行、allman ブレース。JSON/YAML/XML は 2 スペースインデント。
 
-## Secrets & configuration
+## シークレット・設定
 
-- Local config is `local.settings.json` at the repo root — **gitignored, never commit it**. It holds `STEAM_PROFILE_ID` (numeric SteamID64, not a vanity name), `DISCORD_WEBHOOK_URL`, and `ITAD_API_KEY`. In Azure these come from Application Settings.
-- Never hardcode webhook URLs, API keys, or profile IDs; read them via `IConfiguration`.
-- Deployment uses OIDC (`azure/login`); no long-lived Azure credentials are stored in the repo.
+- ローカル設定はリポジトリルートの `local.settings.json`。**gitignore 対象であり、絶対にコミットしない**。`STEAM_PROFILE_ID`(数値の SteamID64。vanity name ではない)、`DISCORD_WEBHOOK_URL`、`ITAD_API_KEY` を保持する。Azure 上ではアプリケーション設定から取得する。
+- Webhook URL・API キー・プロファイル ID を直接コードに記述しない。`IConfiguration` 経由で取得する。
+- デプロイは OIDC(`azure/login`)を使用する。リポジトリに長期的な Azure 認証情報は保存しない。
 
-## Documentation update rules
+## ドキュメント更新ルール
 
-- Adding/renaming a Function → update `Common/FunctionNames.cs` and any relevant `docs/` walkthrough.
-- Changing local setup, required settings keys, or the run/debug flow → update `docs/06-local-development.md`.
-- Changing the orchestration flow or architecture → update `docs/03-architecture-and-flow.md`.
+- Function の追加・改名時 → `Common/FunctionNames.cs` と関連する `docs/` のウォークスルーを更新する。
+- ローカルセットアップ、必要な設定キー、実行/デバッグ手順の変更時 → `docs/06-local-development.md` を更新する。
+- オーケストレーションフローやアーキテクチャの変更時 → `docs/03-architecture-and-flow.md` を更新する。
 
-## Commits
+## コミット
 
-Conventional Commits; descriptions in **Japanese** (matches history). Example: `feat: セール判定に最安値比較を追加`.
+Conventional Commits に従う。説明は **日本語**(履歴に合わせる)。例: `feat: セール判定に最安値比較を追加`。

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,54 @@
+# CLAUDE.md
+
+## Overview
+
+`WatchWishlistSale` is a serverless batch app built on **Azure Durable Functions** (.NET 10, isolated worker model). It runs hourly, crawls a Steam wishlist, detects apps that are on sale and have dropped in price since the last notification, and posts them to Discord. Lowest-ever prices are fetched from IsThereAnyDeal / CheapShark.
+
+## Development commands
+
+- `dotnet restore` — restore dependencies.
+- `dotnet build --configuration Release` — build. Run before committing; CI runs the same. Keep the build warning-free (StyleCop.Analyzers and `GenerateDocumentationFile` warnings are treated as review blockers).
+- `func start` — run locally. Requires **Azurite** (Storage emulator) running in another terminal and a `local.settings.json` file (see below).
+- Manually trigger the timer without waiting for the top of the hour:
+  `POST http://localhost:7071/admin/functions/RunCrawler` with body `{ "input": "" }`.
+
+There is no test project. Verify changes by building and by running the flow locally against Azurite (see `docs/06-local-development.md`).
+
+## Architecture
+
+Durable Functions splits work into three roles. Data flows Trigger → Orchestrator → Activities, with an Entity holding cross-run state.
+
+- `Triggers/` — entry points. `Crawler.cs` is the hourly `TimerTrigger` that starts the orchestration.
+- `Orchestrations/` — `WatchWishlistOrchestrator.cs`. Coordinates activities (fan-out/fan-in). **Must stay deterministic**: no `DateTime.Now`, random, direct I/O, or non-durable async — call activities for anything non-deterministic.
+- `Activities/` — the actual work (HTTP calls, filtering, Discord notification). One class per activity.
+- `Entities/` — `NotificationStateEntity.cs`, a Durable Entity persisting notified-sale state across runs.
+- `Models/` — DTOs grouped by domain: `Wishlist/`, `Pricing/`, `Notification/`.
+- `Common/FunctionNames.cs` — central constants for every Function name.
+- `Program.cs` — DI/host setup (registers `IHttpClientFactory`, OpenTelemetry).
+
+Deeper design and a code walkthrough live in `docs/` (learning-oriented, Japanese).
+
+## Coding conventions
+
+- **Language**: code comments and XML doc comments in **Japanese** (match existing files); log/exception messages in **English**.
+- **XML docs required**: `GenerateDocumentationFile` is on, so every public type/member needs a `///` summary or the build warns.
+- **Function names**: reference `FunctionNames.*` constants, never string literals, for `[Function(...)]` attributes and orchestration/activity/entity calls.
+- **HTTP**: get clients from the injected `IHttpClientFactory` using a named client (`CreateClient(nameof(TheClass))`); do not `new HttpClient()`.
+- **Models**: prefer `record` types; `Nullable` and `ImplicitUsings` are enabled — annotate nullability honestly and rely on implicit usings.
+- **Formatting** (`.editorconfig`, enforced): 4-space indent, **CRLF** line endings, UTF-8, final newline, allman braces. JSON/YAML/XML use 2-space indent.
+
+## Secrets & configuration
+
+- Local config is `local.settings.json` at the repo root — **gitignored, never commit it**. It holds `STEAM_PROFILE_ID` (numeric SteamID64, not a vanity name), `DISCORD_WEBHOOK_URL`, and `ITAD_API_KEY`. In Azure these come from Application Settings.
+- Never hardcode webhook URLs, API keys, or profile IDs; read them via `IConfiguration`.
+- Deployment uses OIDC (`azure/login`); no long-lived Azure credentials are stored in the repo.
+
+## Documentation update rules
+
+- Adding/renaming a Function → update `Common/FunctionNames.cs` and any relevant `docs/` walkthrough.
+- Changing local setup, required settings keys, or the run/debug flow → update `docs/06-local-development.md`.
+- Changing the orchestration flow or architecture → update `docs/03-architecture-and-flow.md`.
+
+## Commits
+
+Conventional Commits; descriptions in **Japanese** (matches history). Example: `feat: セール判定に最安値比較を追加`.


### PR DESCRIPTION
## 概要

エージェント向けドキュメントを整備し、`CLAUDE.md` と `.github/copilot-instructions.md` を新規追加する。どちらも従来存在しなかったため、実際のソースコードと突き合わせて内容を検証した上で新規作成している。

## 変更内容

### 追加: `CLAUDE.md`

AI エージェントが本リポジトリで作業する際の指針をまとめた。

- Overview: Azure Durable Functions (.NET 10, isolated worker) による Steam ウィッシュリスト監視バッチという位置付け
- Development commands: `dotnet restore` / `dotnet build --configuration Release` / `func start` (Azurite + `local.settings.json` 必須)、`POST /admin/functions/RunCrawler` による手動トリガー、テストプロジェクトが無い旨
- Architecture: `Triggers/` → `Orchestrations/` → `Activities/` の流れと `Entities/` によるクロスラン状態、`Common/FunctionNames.cs`、`Program.cs` の DI 構成
- Coding conventions: コメント/XML doc は日本語・ログ/例外は英語、`GenerateDocumentationFile` による XML doc 必須、`FunctionNames.*` 定数の利用、`IHttpClientFactory` 経由の HTTP、`.editorconfig` (4 space・CRLF・allman) の遵守
- Secrets & configuration: `local.settings.json` は gitignore 済み・コミット禁止、`STEAM_PROFILE_ID` / `DISCORD_WEBHOOK_URL` / `ITAD_API_KEY` は `IConfiguration` 経由、デプロイは OIDC

### 追加: `.github/copilot-instructions.md`

Copilot コードレビュー向けに、レビュー観点とフラグすべきでない事項を記述した。

- Durable Functions のオーケストレーター非決定性 (`DateTime.Now`、`Guid.NewGuid()`、直接 I/O、`Task.Delay` 等) の検出
- `Triggers/Crawler.cs` のシングルトンパターン (プロフィール単位の固定インスタンス ID + Running/Pending スキップ) の維持
- 初回実行時の Discord 通知スキップ挙動 (エンティティが `isFirstRun` を報告し、オーケストレーターが通知をスキップ) の維持
- リポジトリで強制される規約 (`FunctionNames` 定数、`IHttpClientFactory`、XML doc、record 型、nullable) の遵守
- シークレットのハードコード禁止、外部 HTTP レスポンスの検証
- `.editorconfig` 由来の書式や日本語コメントをフラグしない旨

## レビューでの検証結果

執筆担当の記述を鵜呑みにせず、実ソースと 1 つずつ突き合わせて再検証した。以下すべて実態と一致することを確認済みで、修正は不要だった。

- `FunctionNames` 定数 / `IHttpClientFactory.CreateClient(nameof(...))` / XML doc 要件: 全 Activity・Trigger で確認
- シングルトンパターン: `Triggers/Crawler.cs` で固定インスタンス ID + Running/Pending スキップを確認
- `isFirstRun` の責務分離: エンティティ `GetSnapshot()` が報告し、オーケストレーターが通知スキップを判断する構造を確認
- コマンド・設定キー・ドキュメントパス (`docs/03`, `docs/06`)・`.editorconfig` 値・CI (`dotnet-ci.yml`)・OIDC デプロイ: いずれも実在・一致
- `AGENTS.md` / `GEMINI.md`、`.codex/` / `.gemini/` ディレクトリ、「相談ルール」節: いずれも本リポジトリに存在しないことを確認 (削除・復元対象なし)
