### PR TITLE
chore: worktree 作成時に local.settings.json を含めるよう .worktreeinclude を追加

### DIFF
--- a/.worktreeinclude
+++ b/.worktreeinclude
@@ -1,0 +1,1 @@
+local.settings.json


### PR DESCRIPTION
## 概要

worktree 作成時に `local.settings.json` を含めるよう `.worktreeinclude` を追加します。

## 追加パターン

- `local.settings.json`

## 根拠

- `.gitignore` で `local.settings.json`(Azure Functions のローカル設定ファイル)が明示的に無視されている
- README.md: `local.settings.json` の作成が必須と明記(詳細は docs/local-development.md 参照)
- docs/configuration.md: ローカル実行時のみ読み込まれる設定ファイルで、`.gitignore` によりクローン直後には存在しないため、記載の JSON テンプレートを参考に手動作成する必要があると説明されている(AzureWebJobsStorage、FUNCTIONS_WORKER_RUNTIME、STEAM_PROFILE_ID、DISCORD_WEBHOOK_URL、ITAD_API_KEY を含む)
- docs/local-development.md: `func start` の前提として設定ファイルの準備手順が説明されている
- `.env` 等の dotenv 系ファイルは使用されておらず、設定は Azure Functions の `local.settings.json` に一本化されている

`.worktreeinclude` が無い場合、新しい worktree を作成するたびにドキュメントを見ながら `local.settings.json` を手動で再作成する必要があるため、本ファイルをコピー対象に含めることで解消します。

## Copilot レビュー

リポジトリ側で Copilot レビュアーが設定されていないため、リクエストできませんでした。

## 関連 Issue

https://github.com/book000/book000/issues/132
