### PR TITLE
feat: デプロイワークフローにインフラコード(Bicep)のCI/CDを統合

### DIFF
--- a/.github/workflows/azure-functions-deploy.yml
+++ b/.github/workflows/azure-functions-deploy.yml
@@ -48,7 +48,7 @@ jobs:
         env:
           DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
           ITAD_API_KEY: ${{ secrets.ITAD_API_KEY }}
-          STEAM_PROFILE_ID: ${{ vars.STEAM_PROFILE_ID }}
+          STEAM_PROFILE_ID: ${{ secrets.STEAM_PROFILE_ID }}
         run: |
           az deployment group what-if \
             --resource-group "${{ vars.AZURE_RESOURCE_GROUP }}" \
@@ -59,7 +59,7 @@ jobs:
         env:
           DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
           ITAD_API_KEY: ${{ secrets.ITAD_API_KEY }}
-          STEAM_PROFILE_ID: ${{ vars.STEAM_PROFILE_ID }}
+          STEAM_PROFILE_ID: ${{ secrets.STEAM_PROFILE_ID }}
         run: |
           az deployment group create \
             --resource-group "${{ vars.AZURE_RESOURCE_GROUP }}" \

--- a/.github/workflows/azure-functions-deploy.yml
+++ b/.github/workflows/azure-functions-deploy.yml
@@ -44,7 +44,7 @@ jobs:
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
-      - name: 👀 Bicep what-if
+      - name: 🔍 Bicep what-if
         env:
           DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
           ITAD_API_KEY: ${{ secrets.ITAD_API_KEY }}

--- a/.github/workflows/azure-functions-deploy.yml
+++ b/.github/workflows/azure-functions-deploy.yml
@@ -9,7 +9,7 @@ on:
 
 concurrency:
   group: azure-deploy
-  cancel-in-progress: false # 進行中の本番デプロイ(Bicep 適用含む)を中断しないため
+  cancel-in-progress: false
 
 env:
   DOTNET_VERSION: "10.0.x"

--- a/.github/workflows/azure-functions-deploy.yml
+++ b/.github/workflows/azure-functions-deploy.yml
@@ -11,6 +11,8 @@ concurrency:
   group: azure-deploy
   cancel-in-progress: false
 
+permissions: {}
+
 env:
   DOTNET_VERSION: "10.0.x"
 

--- a/.github/workflows/azure-functions-deploy.yml
+++ b/.github/workflows/azure-functions-deploy.yml
@@ -9,7 +9,7 @@ on:
 
 concurrency:
   group: azure-deploy
-  cancel-in-progress: true
+  cancel-in-progress: false # 進行中の本番デプロイ(Bicep 適用含む)を中断しないため
 
 env:
   DOTNET_VERSION: "10.0.x"
@@ -43,6 +43,28 @@ jobs:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: 👀 Bicep what-if
+        env:
+          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+          ITAD_API_KEY: ${{ secrets.ITAD_API_KEY }}
+          STEAM_PROFILE_ID: ${{ vars.STEAM_PROFILE_ID }}
+        run: |
+          az deployment group what-if \
+            --resource-group "${{ vars.AZURE_RESOURCE_GROUP }}" \
+            --template-file infra/main.bicep \
+            --parameters infra/main.bicepparam
+
+      - name: 🚀 Deploy Bicep infrastructure
+        env:
+          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+          ITAD_API_KEY: ${{ secrets.ITAD_API_KEY }}
+          STEAM_PROFILE_ID: ${{ vars.STEAM_PROFILE_ID }}
+        run: |
+          az deployment group create \
+            --resource-group "${{ vars.AZURE_RESOURCE_GROUP }}" \
+            --template-file infra/main.bicep \
+            --parameters infra/main.bicepparam
 
       - name: 🚀 Deploy to Azure Functions
         uses: Azure/functions-action@c5060b3b8bb1ebbcb531abd00c822ecbaa8ea656 # v1.5.7

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -20,6 +20,7 @@ GitHub Actions automatically performs the following when triggered by a push to 
 | `AZURE_FUNCTIONAPP_NAME` | Name of the Function App to deploy to |
 | `DISCORD_WEBHOOK_URL` | Bicep parameter (`discordWebhookUrl`) passed to `infra/main.bicep` |
 | `ITAD_API_KEY` | Bicep parameter (`itadApiKey`) passed to `infra/main.bicep` |
+| `STEAM_PROFILE_ID` | Bicep parameter (`steamProfileId`) passed to `infra/main.bicep`. Stored as a secret (rather than a variable) so GitHub Actions masks it in run logs, even though the value itself is not a credential |
 
 These are configured at the repository level (Settings > Secrets and variables > Actions), consistent with the existing `AZURE_*` secrets above. The workflow's `environment: production` currently has no environment-level secrets or protection rules configured.
 
@@ -28,9 +29,8 @@ These are configured at the repository level (Settings > Secrets and variables >
 | Variable Name | Purpose |
 |---|---|
 | `AZURE_RESOURCE_GROUP` | Resource group name passed to `az deployment group what-if`/`create` |
-| `STEAM_PROFILE_ID` | Bicep parameter (`steamProfileId`) passed to `infra/main.bicep` |
 
-These are non-sensitive values, so they are configured as repository variables rather than secrets.
+This is a non-sensitive value, so it is configured as a repository variable rather than a secret.
 
 ## CI (Build Verification)
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -6,7 +6,9 @@ GitHub Actions automatically performs the following when triggered by a push to 
 
 1. Outputs build artifacts with `dotnet publish --configuration Release --output ./output`.
 2. Logs in to Azure using OIDC authentication.
-3. Deploys to the Azure Functions app using `Azure/functions-action`.
+3. Previews infrastructure changes with `az deployment group what-if` against `infra/main.bicep`.
+4. Applies the Bicep template with `az deployment group create`. If this step fails, the job stops and the Function App code deploy below is skipped.
+5. Deploys to the Azure Functions app using `Azure/functions-action`.
 
 ## Required GitHub Secrets
 
@@ -16,13 +18,21 @@ GitHub Actions automatically performs the following when triggered by a push to 
 | `AZURE_TENANT_ID` | Azure AD tenant ID |
 | `AZURE_SUBSCRIPTION_ID` | Azure subscription ID of the deployment target |
 | `AZURE_FUNCTIONAPP_NAME` | Name of the Function App to deploy to |
+| `DISCORD_WEBHOOK_URL` | Bicep parameter (`discordWebhookUrl`) passed to `infra/main.bicep` |
+| `ITAD_API_KEY` | Bicep parameter (`itadApiKey`) passed to `infra/main.bicep` |
 
-These are expected to be configured in the `production` environment of the GitHub repository (see `environment: production` in the workflow).
+These are configured at the repository level (Settings > Secrets and variables > Actions), consistent with the existing `AZURE_*` secrets above. The workflow's `environment: production` currently has no environment-level secrets or protection rules configured.
+
+## Required GitHub Variables
+
+| Variable Name | Purpose |
+|---|---|
+| `AZURE_RESOURCE_GROUP` | Resource group name passed to `az deployment group what-if`/`create` |
+| `STEAM_PROFILE_ID` | Bicep parameter (`steamProfileId`) passed to `infra/main.bicep` |
+
+These are non-sensitive values, so they are configured as repository variables rather than secrets.
 
 ## CI (Build Verification)
 
 [`.github/workflows/dotnet-ci.yml`](../.github/workflows/dotnet-ci.yml) executes `dotnet restore` → `dotnet build` when triggered by `push`/`pull_request` (target branches: `main`/`master`) and verifies the build succeeds.
 
-## Out of Scope
-
-Provisioning procedures for Azure resources themselves (Function App / Storage accounts, etc.) are outside the scope of this document. This document assumes existing Azure resources to which the above workflows deploy code.


### PR DESCRIPTION
Closes #2315

## 概要

PR #2314 で追加済みの Bicep インフラコード(`infra/main.bicep` / `infra/main.bicepparam`)を、デプロイワークフロー(`.github/workflows/azure-functions-deploy.yml`)に統合しました。Bicep テンプレート自体の内容は変更していません。

## 変更内容

- `azure/login` の直後・Function App デプロイの直前に、以下2ステップを追加:
  - `az deployment group what-if`(差分プレビュー、ログに出力)
  - `az deployment group create`(Bicep 適用。失敗時はジョブが停止し、Function App デプロイは実行されない)
- `concurrency.cancel-in-progress` を `true` → `false` に変更(進行中の本番デプロイを中断しないため)
- `docs/deployment.md` を更新(新しいステップの説明、必要なシークレット/変数の表、スコープ外だった記述の削除)

## マージ後に必要な設定

リポジトリの Settings > Secrets and variables > Actions で、以下を追加設定してください(既存の `AZURE_CLIENT_ID` 等と同じくリポジトリレベル):

| 種別 | 名前 | 用途 |
|---|---|---|
| Secret | `DISCORD_WEBHOOK_URL` | Bicep パラメーター `discordWebhookUrl` |
| Secret | `ITAD_API_KEY` | Bicep パラメーター `itadApiKey` |
| Secret | `STEAM_PROFILE_ID` | Bicep パラメーター `steamProfileId`(機密情報ではないが、ログでマスクされるよう Secret とした) |
| Variable | `AZURE_RESOURCE_GROUP` | デプロイ先リソースグループ名 |

また、既存の OIDC サービスプリンシパル(`AZURE_CLIENT_ID`)が対象リソースグループに対して `Microsoft.Web/sites`・`Microsoft.Web/serverfarms`・`Microsoft.Storage/storageAccounts`・`Microsoft.Insights/components`・`Microsoft.OperationalInsights/workspaces` への書き込み権限(Contributor 相当)を持っているか、マージ前に確認してください(deep-review で権限不足の可能性が指摘されました。現状 Function App コードデプロイは成功しているため十分と思われますが未検証です)。

## 検証

- `actionlint .github/workflows/azure-functions-deploy.yml` → エラー0件
- `dotnet build --configuration Release` → エラー0件、警告0件
- `/deep-review`(ローカルdiffモード)を実施し、score 70 の指摘(`STEAM_PROFILE_ID` のログ露出リスク)を修正済み

Spec: https://github.com/tomacheese/watch-wishlist-sale/issues/2315#issuecomment-5372550381
Plan: https://github.com/tomacheese/watch-wishlist-sale/issues/2315#issuecomment-5372598124
